### PR TITLE
Add Socket.dev supply chain scanning

### DIFF
--- a/.github/workflows/socket.yml
+++ b/.github/workflows/socket.yml
@@ -1,0 +1,23 @@
+name: Socket
+
+on:
+  pull_request:
+    paths:
+      - '**/package.json'
+      - '**/package-lock.json'
+      - '**/pyproject.toml'
+      - '**/requirements*.txt'
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - '**/pom.xml'
+      - '**/build.gradle*'
+      - '**/gradle.properties'
+
+jobs:
+  socket:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: socketdev/socket-action@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@
 [![.NET](https://img.shields.io/badge/.NET-7.0-512BD4?logo=dotnet)](KeyOverlay/)
 [![Windows](https://img.shields.io/badge/Windows-10+-0078D4?logo=windows)](https://www.microsoft.com/windows)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Wolren/KeyOverlay/badge)](https://securityscorecards.dev/viewer/?uri=github.com/Wolren/KeyOverlay)
+[![Socket](https://img.shields.io/badge/Socket-Supply%20Chain%20Security-333?logo=socketdotdev)](https://socket.dev)


### PR DESCRIPTION
Adds Socket.dev dependency scanning workflow and badge to protect against supply chain risks (typo-squatting, protestware, abandoned packages, native code risk).